### PR TITLE
Add resolution for xml2js@0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "tsconfig-paths": "4.2.0",
     "typescript": "5.0.4",
     "wait-for-expect": "3.0.2"
+  },
+  "resolutions": {
+    "xml2js": "0.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5865,10 +5865,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-xml2js@^0.4.17:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+xml2js@0.5.0, xml2js@^0.4.17:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
This fixes [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842)